### PR TITLE
Fix dwarf sprite animation

### DIFF
--- a/app/assets/stylesheets/static_pages.css.scss
+++ b/app/assets/stylesheets/static_pages.css.scss
@@ -408,11 +408,11 @@ background-image: image-url('menu_venue.png');
 }
 @-webkit-keyframes jump {
    from { background-position: 0 0; }
-     to { background-position: -2900px 0; }
+     to { background-position: -2700px 0; }
 }
 @keyframes jump {
    from { background-position: 0 0; }
-     to { background-position: -2900px 0; }
+     to { background-position: -2700px 0; }
 }
 #dwarf-scroll {
   background-image: image-url('scroll_all_s.png');


### PR DESCRIPTION
修正水管小人在點擊時的 Sprite 動畫不正常。

發生原因
- 初次進入動畫因為 jQuery 的 Queue 需要用 JS 實做，以 100px 為單位移動 27 Frame 比較好計算
- CSS 版本是 27 Frame 但用 2900px 的 Sprite 寬度，自動計算不影響
- 主因是 27/2900px 的寬度在 JS 尚無法精確呈現，因此修改 Sprite 檔案
