### PR TITLE
Fixed #30, dwarf jump ripple effect too slow

### DIFF
--- a/app/assets/javascripts/home_animation.coffee
+++ b/app/assets/javascripts/home_animation.coffee
@@ -42,10 +42,12 @@ $(document).ready ->
           fx.now = Math.floor(p / columnWidth) * columnWidth # Force override to make sprite animate
       })
 
-  parallelAnimation = (animations, delay) ->
+  parallelAnimation = (animations, delay, next) ->
     delay ||= 200
+    # TODO: Should using "Promise" to catch animation finished time to prevent delay cannot control
+    animations.push(next) if next and typeof next is "function"
     for animation, index in animations
-      setTimeout(animation, index * 200)
+      setTimeout(animation, index * delay)
 
   # Build animation queue
   Pace.on 'done', ->
@@ -62,8 +64,11 @@ $(document).ready ->
       animate($tube, {y: '0%'}, 1500, 'cubic-bezier(1, 0, 0, 1)'),
       queueAnimate([
         animate($dwarf, {scale: 1, delay: 1500}, 1000),
-        spriteAnimate($dwarf, 100, 27, 24),
-        animate($inkWave, {scale: 500, opacity: 0}, 1000, 'cubic-bezier(1, 0, 0, 1)'),
+        (next)-> parallelAnimation([
+          spriteAnimate($dwarf, 100, 27, 24),
+          animate($inkWave, {scale: 500, opacity: 0}, 1000, 'cubic-bezier(1, 0, 0, 1)'),
+        ], 500, next)
         -> $inkWave.hide().dequeue() # Remove inkwave prevent mouse event
       ])
     ])
+    _animationPlayed = true


### PR DESCRIPTION
修正 #30 小人跳躍後的 Ripple Effect 太晚問題。

註：不過仍有限制，目前實做的 Animation 有 Parallel 跟 Queue 兩種，同步式目前無法正常加入 Queue 動畫（目前使用的項目差異不大，看不出來）
