### PR TITLE
Fixed #36 pace loading subpixel smooth edeg problem

### DIFF
--- a/app/assets/stylesheets/pace.scss
+++ b/app/assets/stylesheets/pace.scss
@@ -23,8 +23,8 @@
     position: absolute;
     left: 50%;
     top: 50%;
-    height: 125px;
-    width: 125px !important;
+    height: 124px;
+    width: 124px !important;
 
     background-image: image-url('svg/diamand.svg');
     background-position: center;


### PR DESCRIPTION
下午提到 Loading 的模糊問題剛剛抓到兇手了，是 Webkit 渲染引擎對 sub-pixel 的處理方式問題。

Firefox 會自動做反鋸齒（理論上應該是），但是 Webkit 卻不會所以造成模糊。
修正方式將顯示區域從 `125px` 縮小到 `124px` 得以整除。
- 一般 CSS 不會造成這個問題，但是使用 `transform` 是以 GPU 方式計算，則有 sub-pixel 問題
